### PR TITLE
Migrate to rescript-react

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -9,7 +9,7 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["reason-react"],
+  "bs-dependencies": ["@rescript/react"],
   "reason": {
     "react-jsx": 3
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-component",
     "reason",
     "reason-react",
+    "rescript-react",
     "reasonml",
     "bucklescript"
   ],
@@ -44,19 +45,19 @@
   "devDependencies": {
     "@material-ui/core": "^3.1.1",
     "@material-ui/icons": "^3.0.1",
-    "bs-platform": "8.0.3",
+    "bs-platform": "8.3",
     "husky": "1.3.1",
     "lint-staged": "8.1.5",
     "prettier": "1.17.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "reason-react": "^0.8.0",
+    "@rescript/react": "^0.10.0",
     "semantic-release": "15.13.3"
   },
   "peerDependencies": {
     "@material-ui/core": "^3.1.1",
     "@material-ui/icons": "^3.0.1",
-    "reason-react": "^0.8.0"
+    "@rescript/react": "^0.10.0"
   },
   "husky": {
     "hooks": {

--- a/scripts/generate-bindings.js
+++ b/scripts/generate-bindings.js
@@ -41,7 +41,7 @@ module ${moduleName} = {
         | [@bs.as "large"] \`Large
       ]=?,
     ~nativeColor: string=?,
-    ~style: ReactDOMRe.Style.t=?,
+    ~style: ReactDOM.Style.t=?,
     ~titleAccess: string=?,
     ~viewBox: string=?,
   ) => React.element = "default";

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,11 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
+"@rescript/react@^0.10.0":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@rescript/react/-/react-0.10.1.tgz#ddce66ba664a104354d559c350ca4ebf17ab5a26"
+  integrity sha512-5eIfGnV1yhjv03ktK6fQ6iEfsZKXKXXrq5hx4+ngEY4R/RU8o/oH9ne375m9RJMugV/jsE8hMoEeSSg2YQy3Ag==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -547,10 +552,10 @@ brcast@^3.0.1:
   resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
   integrity sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==
 
-bs-platform@8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.0.3.tgz#574e41ec04fee381d4c400dac547735368caa48f"
-  integrity sha512-I7wulOPM0/NGamwm9CDh9rGjW1oIKltPwwEIOJrL8DBFRXI8OFSACtWGlpaoOw76Xpf+KcVokr00keS2NlzA3A==
+bs-platform@8.3:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.3.3.tgz#68e3796ad0607c55da0f45fe14c0ce0aaf69682c"
+  integrity sha512-ayS5wdvrOX6PxU2wX7O2rLllzsQDzmGq582NNDFwfM6b9HQu7ki242Pc46o2/CnGHHumKVarpX0IZzjC2Llgcg==
 
 btoa-lite@^1.0.0:
   version "1.0.0"
@@ -4444,11 +4449,6 @@ readdir-scoped-modules@^1.0.0:
     dezalgo "^1.0.0"
     graceful-fs "^4.1.2"
     once "^1.3.0"
-
-reason-react@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.8.0.tgz#a55143f95a872596c92b54595e7904c03ee7c9db"
-  integrity sha512-97AfK3eCF6vfP8rnbq3k6GgXsZt//OiPMINTUk5luJ8W0Wt/JaYsDG6eWKP8Zx3gPpxSU1EPjB1pUm6o6fBnFA==
 
 "recompose@0.28.0 - 0.30.0":
   version "0.30.0"


### PR DESCRIPTION
This is a proposal to migrate to rescript-react. Obviously this is a breaking change, and it will allow [the migration of `bs-material-ui`](https://github.com/jsiebern/bs-material-ui/pull/121).

I needed to bump `bs-platform` to 8.3. However, I am not sure if, at this point, it could make sense to directly bump to 9.0 and avoid future problems.